### PR TITLE
added a test case for loading a font from URL in node context

### DIFF
--- a/test/opentypeSpec.js
+++ b/test/opentypeSpec.js
@@ -24,6 +24,19 @@ describe('opentype.js', function() {
         });
     });
 
+    it('can load a font from URL in Node context', function(done) {
+        load('https://opentype.js.org/fonts/Roboto-Black.ttf', null, { isUrl: true }).then((font) => {
+            assert.deepEqual(font.names.fontFamily, {en: 'Roboto Black'});
+            assert.deepEqual(font.names.fontFamily, {en: 'Roboto Black'});
+            assert.equal(font.unitsPerEm, 2048);
+            assert.equal(font.glyphs.length, 1294);
+            const aGlyph = font.charToGlyph('A');
+            assert.equal(aGlyph.unicode, 65);
+            assert.equal(aGlyph.path.commands.length, 15);
+            done();
+        });
+    });
+
     it('can load a OpenType/CFF font', function() {
         const font = loadSync('./fonts/FiraSansOT-Medium.otf');
         assert.deepEqual(font.names.fontFamily, {en: 'Fira Sans OT Medium'});


### PR DESCRIPTION
I added a test case for loading the font from URL in Node context (which is where the tests are run)